### PR TITLE
Update requirement for elastic/openapi-codegen-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "git@github.com:satrun77/openapi-codegen-php.git"
+      "url": "git@github.com:silverstripeltd/openapi-codegen-php.git"
     }
   ]
 }


### PR DESCRIPTION
Update requirement for elastic/openapi-codegen-php to use silverstripeltd module.
The main purpose for this (aside from moving the requirement to the silverstripeltd account) is to allow requirement of silverstripeltd/RingPHP, adding php8 support