### PR TITLE
Upgrade for PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require" : {
     "php" : "^5.6|^7.0|^8.0",
-    "elastic/openapi-codegen" : "dev-cms5-support",
+    "elastic/openapi-codegen" : "2.1.0",
     "psr/log" : "^1.0. | ^3.0"
   },
   "require-dev" : {


### PR DESCRIPTION
Updating to use `2.1.0` version for openapi-codegen package which has PHP 8.2 support.